### PR TITLE
Support useInsertionEffect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,6 @@
       "name": "stitches",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-polymorphic": "0.0.14",
-        "@radix-ui/react-separator": "0.1.0",
         "@skypack/package-check": "0.2.2",
         "@types/node": "16.9.6",
         "@types/react": "17.0.24",
@@ -27,8 +25,9 @@
         "esbuild": "0.13.2",
         "eslint": "7.32.0",
         "nodemon": "2.0.13",
-        "react": "17.0.2",
-        "react-test-renderer": "17.0.2",
+        "prettier": "2.6.2",
+        "react": "18.0.0",
+        "react-test-renderer": "18.0.0",
         "terser": "5.9.0",
         "typescript": "4.6.2"
       },
@@ -123,18 +122,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -227,353 +214,9 @@
       }
     },
     "node_modules/@radix-ui/colors": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.7.tgz",
-      "integrity": "sha512-E6+ZPQ+FFn1/NZ4c/KRvZTu9KjC/MXrbJNETYs1HKe96gyxQivPu65FkhOsRnPigvJ0YJ9ZxYGxayqDNmaC1cQ==",
-      "license": "MIT"
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.0.5.tgz",
-      "integrity": "sha512-VeL6A5LpKYRJhDDj5tCTnzP3zm+FnvybsAkgBHQ4LUPPBnqRdWLoyKpZhlwFze/z22QHINaTIcE9Z/fTcrUR1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.0.5.tgz",
-      "integrity": "sha512-O9mH9X/2EwuAEEoZXrU4alcrRbAhhZHGpIJ5bOH6rmRcokhaoWRBY1tOEe2lgHdb/bkKrY+viLi4Zq8Ju6/09Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.0.5.tgz",
-      "integrity": "sha512-bwrzAc0qc2EPepSTLBT4+93uCiI9wP78VSmPg2K+k71O/vpx7dPs0VqrewwCBNCHT54NIwaRr2hEsm2uqYi02A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-dialog": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.0.20.tgz",
-      "integrity": "sha512-fXgWxWyvmNiimxrFGdvUNve0tyQEFyPwrNgkSi6Xiha9cX8sqWdiYWq500zhzUQQFJVS7No73ylx8kgrI7SoLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.0.5",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-context": "0.0.5",
-        "@radix-ui/react-dismissable-layer": "0.0.15",
-        "@radix-ui/react-focus-guards": "0.0.7",
-        "@radix-ui/react-focus-scope": "0.0.15",
-        "@radix-ui/react-id": "0.0.6",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-portal": "0.0.15",
-        "@radix-ui/react-presence": "0.0.15",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-slot": "0.0.12",
-        "@radix-ui/react-use-controllable-state": "0.0.6",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0",
-        "react-dom": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.0.15.tgz",
-      "integrity": "sha512-2zABi8rh/t6liFfRLBw6h+B7MNNFxVQrgYfWRMs1elNX41z3G2vLoBlWdqGzAlYrtqEr/6CL4pQfhwVtd7rNGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.0.5",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-body-pointer-events": "0.0.7",
-        "@radix-ui/react-use-callback-ref": "0.0.5",
-        "@radix-ui/react-use-escape-keydown": "0.0.6"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.0.7.tgz",
-      "integrity": "sha512-enAsmrUunptHVzPLTuZqwTP/X3WFBnyJ/jP9W+0g+bRvI3o7V1kxNc+T2Rp1eRTFBW+lUNnt08qkugPytyTRog==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.0.15.tgz",
-      "integrity": "sha512-zNgEe1lyLPfxa003VD8lCXaadGqCYhboA3X1WDNGes74lzJgLOPJgzLI0F/ksSokkx/yDDdReyOWui3/LCTqTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.0.6.tgz",
-      "integrity": "sha512-PzmraF34fYggsYvTIZVJ5S68WMp3aKUN3HkSmGnz4zn9zpRjkAbbg7Xn3ueQI3FQsLWKgyUfnpsmWFDndpcqYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.14.tgz",
-      "integrity": "sha512-9nsMZEDU3LeIUeHJrpkkhZVxu/9Fc7P2g2I3WR+uA9mTbNC3hGaabi0dV6wg0CfHb+m4nSs1pejbE/5no3MJTA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.0.15.tgz",
-      "integrity": "sha512-qMESsdqph1gbRGzy9oSzUoeZYXnR2egXVcEZDqmesfn8w/o1rC1wadKkyBf7qo/YyjUX4mvXknAA+ftp1aQp+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0",
-        "react-dom": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.0.15.tgz",
-      "integrity": "sha512-+5+ePKUdTkqN1ze7nYmcoeHSsmKCcREwt0NhvNgDocPaqEUoZSkK9Mq6eMiMXSj02NkXH9P+bK32VCClYFnMBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.0.15.tgz",
-      "integrity": "sha512-Y7JLnen/G3AT0cQXXkBo3A1OuWaKGerkd2gKs0Fuqxv+kTxEmYoqSp/soo0Mm3Ccw61LKLQAjPiE37GK9/Zqwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-polymorphic": "0.0.13"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-separator": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-0.1.0.tgz",
-      "integrity": "sha512-TxA93lNQB6ZLjAit2juo38ow4BVcF+BjgDbsh2+rWW4AQcxXDwbKXA4962PSxtXTnoQER5fJY2Y0OR97CFx7Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-compose-refs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.0.tgz",
-      "integrity": "sha512-ydO24k5Cvry5RCMfm5OJNnIwvxSIUuUZ3Kf6bu1GaSsDfBKiv5JeuQkipURW28KlX7I85Jr/I02JlE+Ec4HmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.0.tgz",
-      "integrity": "sha512-ZuvAUhSK9EAE42b3+K7k7w4nF1uF+Wd4bFj2OCE1aSiW3tgiu7ZU+J61m2+RIDps0WLu95PUx6eZrnpfqBXFRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.0.12.tgz",
-      "integrity": "sha512-Em8P/xYyh3O/32IhrmARJNH+J/XCAVnw6h2zGu6oeReliIX7ktU67pMSeyyIZiU2hNXzaXYB/xDdixizQe/DGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-body-pointer-events": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.0.7.tgz",
-      "integrity": "sha512-mXAGyb8mhVjRqtpKPeZePuvee40bgsWpt378oQrIcLU1uZNbNX9eyrIPnnL9OMLAvxqloAOClVj0PZ1bMQmfDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.0.5.tgz",
-      "integrity": "sha512-z1AI221vmq9f3vsDyrCsGLCatKagbM1YeCGdRMhMsUBzFFCaJ+Axyoe/ndVqW8wwsraGWr1zYVAhIEdlC0GvPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.6.tgz",
-      "integrity": "sha512-fBk4hUSKc4N7X/NAaifWYfKKfNuOB9xvj0MBQQYS5oOTNRgg4y8/Ax3jZ0adsplXDm7ix75sxqWm0nrvUoAjcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.0.6.tgz",
-      "integrity": "sha512-MJpVj21BYwWllmp2xbXPqpKPssJ1WWrZi+Qx7PY5hVcBhQr5Jo6yKwIX677pH5Yql95ENTTT5LW3q+LVFYIISw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.0.5.tgz",
-      "integrity": "sha512-bNPW2JNOr/p2hXr0hfKKqrEy5deNSRF17sw3l9Z7qlEnvIbBtQ7iwY/wrxIz5P7XFyYGoXodIUDH5G8PEucE3A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
+      "integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -1169,18 +812,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/aria-hidden": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
-      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
-      "license": "ISC",
-      "dependencies": {
-        "tslib": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      }
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1551,12 +1182,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-      "license": "MIT"
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/dir-glob": {
@@ -2055,15 +1680,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "license": "MIT"
     },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -2301,15 +1917,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-binary-path": {
@@ -2742,7 +2349,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2876,16 +2482,17 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true,
-      "license": "MIT",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -2998,117 +2605,52 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "node_modules/react-remove-scroll": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.4.tgz",
-      "integrity": "sha512-EyC5ohYhaeKbThMSQxuN2i+QC5HqV3AJvNZKEdiATITexu0gHm00+5ko0ltNS1ajYJVeDgVG2baRSCei0AUWlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.1.0",
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.3",
-        "use-sidecar": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
-      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
+      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw=="
     },
     "node_modules/react-shallow-renderer": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
-      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "license": "MIT",
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dependencies": {
         "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
-      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-SyZTP/FSkwfiKOZuTZiISzsrC8A80KNlQ8PyyoGoOq+VzMAab6Em1POK/CiX3+XyXG6oiJa1C53zYDbdrJu9fw==",
       "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
+        "react-is": "^18.0.0",
         "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.21.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/readdirp": {
@@ -3122,12 +2664,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "license": "MIT"
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -3238,15 +2774,6 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {
@@ -3649,40 +3176,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/use-callback-ref": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
-      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
-      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -3786,15 +3279,15 @@
     },
     "packages/core": {
       "name": "@implydata/stitches-core",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT"
     },
     "packages/react": {
       "name": "@implydata/stitches-react",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT",
       "devDependencies": {
-        "react": "17.0.2"
+        "react": "18.0.0"
       },
       "peerDependencies": {
         "react": ">= 16.3.0"
@@ -3802,16 +3295,14 @@
     },
     "packages/stringify": {
       "name": "@implydata/stitches-stringify",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT"
     },
     "packages/test": {
       "name": "@implydata/stitches-test",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "dependencies": {
-        "@radix-ui/colors": "0.1.7",
-        "@radix-ui/react-dialog": "0.0.20",
-        "@radix-ui/react-polymorphic": "0.0.13",
+        "@radix-ui/colors": "0.1.8",
         "@types/lodash.merge": "4.6.6"
       },
       "devDependencies": {
@@ -3821,18 +3312,9 @@
         "eslint-config-prettier": "^4.1.0",
         "eslint-config-react": "^1.1.7",
         "eslint-plugin-prettier": "^3.0.1",
-        "prettier": "^1.16.4",
-        "react": "17.0.2",
+        "prettier": "^2.6.2",
+        "react": "18.0.0",
         "typescript": "^4.6.2"
-      }
-    },
-    "packages/test/node_modules/@radix-ui/react-polymorphic": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-      "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
       }
     },
     "packages/test/node_modules/@stitches/react": {
@@ -3985,14 +3467,6 @@
         }
       }
     },
-    "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -4030,7 +3504,7 @@
     "@implydata/stitches-react": {
       "version": "file:packages/react",
       "requires": {
-        "react": "17.0.2"
+        "react": "18.0.0"
       }
     },
     "@implydata/stitches-stringify": {
@@ -4039,9 +3513,7 @@
     "@implydata/stitches-test": {
       "version": "file:packages/test",
       "requires": {
-        "@radix-ui/colors": "0.1.7",
-        "@radix-ui/react-dialog": "0.0.20",
-        "@radix-ui/react-polymorphic": "0.0.13",
+        "@radix-ui/colors": "0.1.8",
         "@stitches/react": "1.2.6",
         "@types/lodash.merge": "4.6.6",
         "@typescript-eslint/eslint-plugin": "^1.6.0",
@@ -4049,17 +3521,11 @@
         "eslint-config-prettier": "^4.1.0",
         "eslint-config-react": "^1.1.7",
         "eslint-plugin-prettier": "^3.0.1",
-        "prettier": "^1.16.4",
-        "react": "17.0.2",
+        "prettier": "^2.6.2",
+        "react": "18.0.0",
         "typescript": "^4.6.2"
       },
       "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        },
         "@stitches/react": {
           "version": "1.2.6",
           "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.6.tgz",
@@ -4139,263 +3605,9 @@
       }
     },
     "@radix-ui/colors": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.7.tgz",
-      "integrity": "sha512-E6+ZPQ+FFn1/NZ4c/KRvZTu9KjC/MXrbJNETYs1HKe96gyxQivPu65FkhOsRnPigvJ0YJ9ZxYGxayqDNmaC1cQ=="
-    },
-    "@radix-ui/primitive": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.0.5.tgz",
-      "integrity": "sha512-VeL6A5LpKYRJhDDj5tCTnzP3zm+FnvybsAkgBHQ4LUPPBnqRdWLoyKpZhlwFze/z22QHINaTIcE9Z/fTcrUR1g==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-compose-refs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.0.5.tgz",
-      "integrity": "sha512-O9mH9X/2EwuAEEoZXrU4alcrRbAhhZHGpIJ5bOH6rmRcokhaoWRBY1tOEe2lgHdb/bkKrY+viLi4Zq8Ju6/09Q==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-context": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.0.5.tgz",
-      "integrity": "sha512-bwrzAc0qc2EPepSTLBT4+93uCiI9wP78VSmPg2K+k71O/vpx7dPs0VqrewwCBNCHT54NIwaRr2hEsm2uqYi02A==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-dialog": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.0.20.tgz",
-      "integrity": "sha512-fXgWxWyvmNiimxrFGdvUNve0tyQEFyPwrNgkSi6Xiha9cX8sqWdiYWq500zhzUQQFJVS7No73ylx8kgrI7SoLw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.0.5",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-context": "0.0.5",
-        "@radix-ui/react-dismissable-layer": "0.0.15",
-        "@radix-ui/react-focus-guards": "0.0.7",
-        "@radix-ui/react-focus-scope": "0.0.15",
-        "@radix-ui/react-id": "0.0.6",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-portal": "0.0.15",
-        "@radix-ui/react-presence": "0.0.15",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-slot": "0.0.12",
-        "@radix-ui/react-use-controllable-state": "0.0.6",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.4.0"
-      },
-      "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        }
-      }
-    },
-    "@radix-ui/react-dismissable-layer": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.0.15.tgz",
-      "integrity": "sha512-2zABi8rh/t6liFfRLBw6h+B7MNNFxVQrgYfWRMs1elNX41z3G2vLoBlWdqGzAlYrtqEr/6CL4pQfhwVtd7rNGw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.0.5",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-body-pointer-events": "0.0.7",
-        "@radix-ui/react-use-callback-ref": "0.0.5",
-        "@radix-ui/react-use-escape-keydown": "0.0.6"
-      },
-      "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        }
-      }
-    },
-    "@radix-ui/react-focus-guards": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.0.7.tgz",
-      "integrity": "sha512-enAsmrUunptHVzPLTuZqwTP/X3WFBnyJ/jP9W+0g+bRvI3o7V1kxNc+T2Rp1eRTFBW+lUNnt08qkugPytyTRog==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-focus-scope": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.0.15.tgz",
-      "integrity": "sha512-zNgEe1lyLPfxa003VD8lCXaadGqCYhboA3X1WDNGes74lzJgLOPJgzLI0F/ksSokkx/yDDdReyOWui3/LCTqTw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      },
-      "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        }
-      }
-    },
-    "@radix-ui/react-id": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.0.6.tgz",
-      "integrity": "sha512-PzmraF34fYggsYvTIZVJ5S68WMp3aKUN3HkSmGnz4zn9zpRjkAbbg7Xn3ueQI3FQsLWKgyUfnpsmWFDndpcqYg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-polymorphic": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.14.tgz",
-      "integrity": "sha512-9nsMZEDU3LeIUeHJrpkkhZVxu/9Fc7P2g2I3WR+uA9mTbNC3hGaabi0dV6wg0CfHb+m4nSs1pejbE/5no3MJTA==",
-      "requires": {}
-    },
-    "@radix-ui/react-portal": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.0.15.tgz",
-      "integrity": "sha512-qMESsdqph1gbRGzy9oSzUoeZYXnR2egXVcEZDqmesfn8w/o1rC1wadKkyBf7qo/YyjUX4mvXknAA+ftp1aQp+w==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-polymorphic": "0.0.13",
-        "@radix-ui/react-primitive": "0.0.15",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      },
-      "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        }
-      }
-    },
-    "@radix-ui/react-presence": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.0.15.tgz",
-      "integrity": "sha512-+5+ePKUdTkqN1ze7nYmcoeHSsmKCcREwt0NhvNgDocPaqEUoZSkK9Mq6eMiMXSj02NkXH9P+bK32VCClYFnMBQ==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      }
-    },
-    "@radix-ui/react-primitive": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.0.15.tgz",
-      "integrity": "sha512-Y7JLnen/G3AT0cQXXkBo3A1OuWaKGerkd2gKs0Fuqxv+kTxEmYoqSp/soo0Mm3Ccw61LKLQAjPiE37GK9/Zqwg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-polymorphic": "0.0.13"
-      },
-      "dependencies": {
-        "@radix-ui/react-polymorphic": {
-          "version": "0.0.13",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.13.tgz",
-          "integrity": "sha512-0sGqBp+v9/yrsMhPfAejxcem2MwAFgaSAxF3Sieaklm6ZVYM/hTZxxWI5NVOLGV+482GwW0wIqwpVUzREjmh+w==",
-          "requires": {}
-        }
-      }
-    },
-    "@radix-ui/react-separator": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-0.1.0.tgz",
-      "integrity": "sha512-TxA93lNQB6ZLjAit2juo38ow4BVcF+BjgDbsh2+rWW4AQcxXDwbKXA4962PSxtXTnoQER5fJY2Y0OR97CFx7Zg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "0.1.0"
-      },
-      "dependencies": {
-        "@radix-ui/react-compose-refs": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-          "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10"
-          }
-        },
-        "@radix-ui/react-primitive": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.0.tgz",
-          "integrity": "sha512-ydO24k5Cvry5RCMfm5OJNnIwvxSIUuUZ3Kf6bu1GaSsDfBKiv5JeuQkipURW28KlX7I85Jr/I02JlE+Ec4HmWA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-slot": "0.1.0"
-          }
-        },
-        "@radix-ui/react-slot": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.0.tgz",
-          "integrity": "sha512-ZuvAUhSK9EAE42b3+K7k7w4nF1uF+Wd4bFj2OCE1aSiW3tgiu7ZU+J61m2+RIDps0WLu95PUx6eZrnpfqBXFRg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-compose-refs": "0.1.0"
-          }
-        }
-      }
-    },
-    "@radix-ui/react-slot": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.0.12.tgz",
-      "integrity": "sha512-Em8P/xYyh3O/32IhrmARJNH+J/XCAVnw6h2zGu6oeReliIX7ktU67pMSeyyIZiU2hNXzaXYB/xDdixizQe/DGA==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.0.5"
-      }
-    },
-    "@radix-ui/react-use-body-pointer-events": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.0.7.tgz",
-      "integrity": "sha512-mXAGyb8mhVjRqtpKPeZePuvee40bgsWpt378oQrIcLU1uZNbNX9eyrIPnnL9OMLAvxqloAOClVj0PZ1bMQmfDw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "0.0.5"
-      }
-    },
-    "@radix-ui/react-use-callback-ref": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.0.5.tgz",
-      "integrity": "sha512-z1AI221vmq9f3vsDyrCsGLCatKagbM1YeCGdRMhMsUBzFFCaJ+Axyoe/ndVqW8wwsraGWr1zYVAhIEdlC0GvPg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-use-controllable-state": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.0.6.tgz",
-      "integrity": "sha512-fBk4hUSKc4N7X/NAaifWYfKKfNuOB9xvj0MBQQYS5oOTNRgg4y8/Ax3jZ0adsplXDm7ix75sxqWm0nrvUoAjcw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      }
-    },
-    "@radix-ui/react-use-escape-keydown": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.0.6.tgz",
-      "integrity": "sha512-MJpVj21BYwWllmp2xbXPqpKPssJ1WWrZi+Qx7PY5hVcBhQr5Jo6yKwIX677pH5Yql95ENTTT5LW3q+LVFYIISw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.0.5"
-      }
-    },
-    "@radix-ui/react-use-layout-effect": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.0.5.tgz",
-      "integrity": "sha512-bNPW2JNOr/p2hXr0hfKKqrEy5deNSRF17sw3l9Z7qlEnvIbBtQ7iwY/wrxIz5P7XFyYGoXodIUDH5G8PEucE3A==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
+      "integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -4783,14 +3995,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "aria-hidden": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.1.3.tgz",
-      "integrity": "sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==",
-      "requires": {
-        "tslib": "^1.0.0"
-      }
-    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -5035,11 +4239,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
-    },
-    "detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -5379,11 +4578,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
-    "get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
-    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -5540,14 +4734,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -5923,10 +5109,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -5998,68 +5183,45 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-    },
-    "react-remove-scroll": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.4.tgz",
-      "integrity": "sha512-EyC5ohYhaeKbThMSQxuN2i+QC5HqV3AJvNZKEdiATITexu0gHm00+5ko0ltNS1ajYJVeDgVG2baRSCei0AUWlQ==",
-      "requires": {
-        "react-remove-scroll-bar": "^2.1.0",
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.3",
-        "use-sidecar": "^1.0.1"
-      }
-    },
-    "react-remove-scroll-bar": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
-      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
-      "requires": {
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0"
-      }
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.0.0.tgz",
+      "integrity": "sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw=="
     },
     "react-shallow-renderer": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
-      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "requires": {
         "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
-      }
-    },
-    "react-style-singleton": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
-      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
-      "requires": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^1.0.0"
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-SyZTP/FSkwfiKOZuTZiISzsrC8A80KNlQ8PyyoGoOq+VzMAab6Em1POK/CiX3+XyXG6oiJa1C53zYDbdrJu9fw==",
       "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
+        "react-is": "^18.0.0",
         "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.21.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+          "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        }
       }
     },
     "readdirp": {
@@ -6069,11 +5231,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -6133,15 +5290,6 @@
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "requires": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "semver": {
@@ -6410,21 +5558,6 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "requires": {
         "prepend-http": "^2.0.0"
-      }
-    },
-    "use-callback-ref": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
-      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
-      "requires": {}
-    },
-    "use-sidecar": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
-      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
-      "requires": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^1.9.3"
       }
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "esbuild": "0.13.2",
     "eslint": "7.32.0",
     "nodemon": "2.0.13",
-    "react": "17.0.2",
-    "react-test-renderer": "17.0.2",
+    "react": "18.0.0",
+    "react-test-renderer": "18.0.0",
     "terser": "5.9.0",
     "typescript": "4.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     ]
   },
   "dependencies": {
-    "@radix-ui/react-polymorphic": "0.0.14",
-    "@radix-ui/react-separator": "0.1.0",
     "@skypack/package-check": "0.2.2",
     "@types/node": "16.9.6",
     "@types/react": "17.0.24",
@@ -50,6 +48,7 @@
     "esbuild": "0.13.2",
     "eslint": "7.32.0",
     "nodemon": "2.0.13",
+    "prettier": "2.6.2",
     "react": "18.0.0",
     "react-test-renderer": "18.0.0",
     "terser": "5.9.0",

--- a/packages/core/src/createStitches.js
+++ b/packages/core/src/createStitches.js
@@ -11,7 +11,7 @@ import { createSheet } from './sheet.js'
 
 const createCssMap = createMemo()
 
-export const createStitches = (config) => {
+export const createStitches = (config, alwaysDeferred) => {
 	let didRun = false
 
 	const instance = createCssMap(config, (initConfig) => {
@@ -40,7 +40,7 @@ export const createStitches = (config) => {
 		const sheet = createSheet(root)
 
 		const returnValue = {
-			css: createCssFunction(config, sheet),
+			css: createCssFunction(config, sheet, alwaysDeferred),
 			globalCss: createGlobalCssFunction(config, sheet),
 			keyframes: createKeyframesFunction(config, sheet),
 			createTheme: createCreateThemeFunction(config, sheet),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
     "Jonathan Neal <jonathan@modulz.app>"
   ],
   "devDependencies": {
-    "react": "17.0.2"
+    "react": "18.0.0"
   },
   "peerDependencies": {
     "react": ">= 16.3.0"

--- a/packages/react/src/createStitches.js
+++ b/packages/react/src/createStitches.js
@@ -3,12 +3,18 @@ import { createStitches as createStitchesCore } from '../../core/src/createStitc
 import { createStyledFunction } from './features/styled.js'
 
 // Always use a deferred injector with React 18+ (in browser)
-const alwaysDeferred = typeof window !== 'undefined' && typeof React.useInsertionEffect === 'function'
+const supportsInsertionEffects = typeof window !== 'undefined' && typeof React.useInsertionEffect === 'function'
+
+// prettier-ignore
+const useGlobalCss = supportsInsertionEffects
+	? (css) => { React.useInsertionEffect(css) }
+	: (css) => { React.useLayoutEffect(css, []) }
 
 export const createStitches = (init) => {
-	const instance = createStitchesCore(init, alwaysDeferred)
+	const instance = createStitchesCore(init, /* alwaysDeferred */ supportsInsertionEffects)
 
-	instance.styled = createStyledFunction(instance, /* supportsInsertionEffects */ alwaysDeferred)
+	instance.styled = createStyledFunction(instance, supportsInsertionEffects)
+	instance.useGlobalCss = useGlobalCss
 
 	return instance
 }

--- a/packages/react/src/createStitches.js
+++ b/packages/react/src/createStitches.js
@@ -1,10 +1,14 @@
+import React from 'react'
 import { createStitches as createStitchesCore } from '../../core/src/createStitches.js'
 import { createStyledFunction } from './features/styled.js'
 
-export const createStitches = (init) => {
-	const instance = createStitchesCore(init)
+// Always use a deferred injector with React 18+ (in browser)
+const alwaysDeferred = typeof window !== 'undefined' && typeof React.useInsertionEffect === 'function'
 
-	instance.styled = createStyledFunction(instance)
+export const createStitches = (init) => {
+	const instance = createStitchesCore(init, alwaysDeferred)
+
+	instance.styled = createStyledFunction(instance, /* supportsInsertionEffects */ alwaysDeferred)
 
 	return instance
 }

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -11,7 +11,7 @@ import { createCssFunction } from '../../../core/src/features/css.js'
 const createCssFunctionMap = createMemo()
 
 /** Returns a function that applies component styles. */
-export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }, supportsInsertionEffects) => (
+export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }, supportsInsertionEffects) =>
 	createCssFunctionMap(config, () => {
 		const css = createCssFunction(config, sheet, supportsInsertionEffects)
 
@@ -20,7 +20,7 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 			const DefaultType = cssComponent[internal].type
 
 			const styledComponent = React.forwardRef((props, ref) => {
-				const Type = props && props.as || DefaultType
+				const Type = (props && props.as) || DefaultType
 
 				const { props: forwardProps, deferredInjector } = cssComponent(props)
 
@@ -29,7 +29,7 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 				forwardProps.ref = ref
 
 				if (supportsInsertionEffects) {
-					// This technically violates the rules of hooks, but 'alwaysDeferred'
+					// This technically violates the rules of hooks, but 'supportsInsertionEffects'
 					// will never change values between renders
 					React.useInsertionEffect(() => void deferredInjector())
 				} else if (deferredInjector) {
@@ -52,4 +52,3 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 		return styled
 	})
-)

--- a/packages/react/src/features/styled.js
+++ b/packages/react/src/features/styled.js
@@ -11,9 +11,9 @@ import { createCssFunction } from '../../../core/src/features/css.js'
 const createCssFunctionMap = createMemo()
 
 /** Returns a function that applies component styles. */
-export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }) => (
+export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {GroupSheet} */ sheet }, supportsInsertionEffects) => (
 	createCssFunctionMap(config, () => {
-		const css = createCssFunction(config, sheet)
+		const css = createCssFunction(config, sheet, supportsInsertionEffects)
 
 		const styled = (...args) => {
 			const cssComponent = css(...args)
@@ -28,7 +28,11 @@ export const createStyledFunction = ({ /** @type {Config} */ config, /** @type {
 
 				forwardProps.ref = ref
 
-				if (deferredInjector) {
+				if (supportsInsertionEffects) {
+					// This technically violates the rules of hooks, but 'alwaysDeferred'
+					// will never change values between renders
+					React.useInsertionEffect(() => void deferredInjector())
+				} else if (deferredInjector) {
 					return React.createElement(React.Fragment, null, React.createElement(Type, forwardProps), React.createElement(deferredInjector, null))
 				}
 

--- a/packages/react/types/stitches.d.ts
+++ b/packages/react/types/stitches.d.ts
@@ -274,6 +274,7 @@ export default interface Stitches<
 			CSSUtil.CSS<Media, Theme, ThemeMap, Utils>
 		>
 	}
+	useGlobalCss(css: () => string): void
 }
 
 type ThemeTokens<Values, Prefix> = {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -16,15 +16,13 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-config-react": "^1.1.7",
     "eslint-plugin-prettier": "^3.0.1",
-    "prettier": "^1.16.4",
+    "prettier": "^2.6.2",
     "react": "18.0.0",
     "typescript": "^4.6.2"
   },
   "private": true,
   "dependencies": {
-    "@radix-ui/colors": "0.1.7",
-    "@radix-ui/react-dialog": "0.0.20",
-    "@radix-ui/react-polymorphic": "0.0.13",
+    "@radix-ui/colors": "0.1.8",
     "@types/lodash.merge": "4.6.6"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -17,7 +17,7 @@
     "eslint-config-react": "^1.1.7",
     "eslint-plugin-prettier": "^3.0.1",
     "prettier": "^1.16.4",
-    "react": "17.0.2",
+    "react": "18.0.0",
     "typescript": "^4.6.2"
   },
   "private": true,


### PR DESCRIPTION
Experimental support for the `useInsertionEffect` hook in React 18.

- `styled`: always use a deferred injector and wrap it with the hook
- `globalCss`: add a `useGlobalCss` hook that uses insertion effects if available

```tsx
const globalStyles = globalCss({
  body: { margin: 0 },
});

() => {
  useGlobalCss(globalStyles);
  return <div />;
};
```